### PR TITLE
Add 'name' source key

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The value for the `sources` key is a non-empty list of source descriptions, each
 
 | key | value | optional? |
 |-|-|-|
-| `name` | The UI name for the source | optional |
+| `name` | The UI name for the source | optional: it has no significance on the data, but it can be helpful for designers to identify the source |
 | `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. If an axis is omitted, the default value for that axis is used. | mandatory |
 | `layername` | The UFO layer containing the source glyph data | optional: if not given, the default layer is used |
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The value for the `sources` key is a non-empty list of source descriptions, each
 
 | key | value | optional? |
 |-|-|-|
-| `name` | The UI name for the source | optional: it has no significance on the data, but it can be helpful for designers to identify the source |
+| `name` | The UI name for the source | optional: it has no significance for the data, but it can be helpful for designers to identify the source |
 | `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. If an axis is omitted, the default value for that axis is used. | mandatory |
 | `layername` | The UFO layer containing the source glyph data | optional: if not given, the default layer is used |
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The value for the `sources` key is a non-empty list of source descriptions, each
 
 | key | value | optional? |
 |-|-|-|
+| `name` | The UI name for the source | optional |
 | `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. If an axis is omitted, the default value for that axis is used. | mandatory |
 | `layername` | The UFO layer containing the source glyph data | optional: if not given, the default layer is used |
 


### PR DESCRIPTION
The source name is just a UI field, it has no meaning for building fonts.