### PR TITLE
Sync with Fontra implementation

### DIFF
--- a/ExampleVariableComponent/ExampleVariableComponent_Default.ufo/glyphs/V_ariableG_lyph.glif
+++ b/ExampleVariableComponent/ExampleVariableComponent_Default.ufo/glyphs/V_ariableG_lyph.glif
@@ -38,15 +38,6 @@
         <key>sources</key>
         <array>
           <dict>
-            <key>location</key>
-            <dict>
-              <key>height</key>
-              <real>20.0</real>
-              <key>width</key>
-              <real>20.0</real>
-            </dict>
-          </dict>
-          <dict>
             <key>layername</key>
             <string>width=200,height=700</string>
             <key>location</key>

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If there are no variable components, the list should *not* be written to `glyph.
 
 ### Base name
 
-The value for the `base` key is the glyph name of the referenced glyph. (The name for this key is chosen for symmetry with the `<component>` element in UFO glyphs, which has a `base` attribute with the same function.)
+The value for the `base` key is the glyph name of the referenced glyph. The name for this key is chosen for symmetry with the `<component>` element in UFO glyphs, which has a `base` attribute with the same function.
 
 ### Component Transformation
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The value for the `sources` key is list of source descriptions, each of which is
 | key | value | optional? |
 |-|-|-|
 | `name` | The UI name for the source | mandatory -- it has no significance for the data, but it is helpful for designers to identify the source |
-| `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. Each axis name must either be a global axis name, or a local axis name, defined for this glyph. If an axis is omitted, the default value for that axis is used. | mandatory |
+| `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. Each axis name must either be a global axis name, or a local axis name, defined for this glyph. If an axis is omitted, the default value for that axis is implied. | mandatory |
 | `layername` | The UFO layer containing the source glyph data | optional: if not given, the default layer is used |
 
 ### Which UFO?

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The order of operations is significant.
 
 Example Python code implementing this is included here: [compose_transform.py](compose_transform.py). The example code also includes a method for decomposing an Affine transform into decomposed parameters.
 
-### Axis values versus nested components
+### Axis values and nested components
 
 Each glyph's rendered location is determined by its parent composite. If there is no parent, the global design space location is used.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These items correspond to the same-named `.designspace` `<axis>` attributes. All
 
 ### Variation sources
 
-Each variation source defines a location in the augmented design space. The location _implicitly_ determines in which UFO the glyph source data is stored. The UFO _layer_ is defined explicitly.
+Each variation source defines a location in the augmented design space. The _location_ implicitly determines in which UFO the glyph source data is stored. The UFO _layer_ is defined explicitly.
 
 The value for the `sources` key is list of source descriptions, each of which is a dictionary with the following fields:
 
@@ -115,7 +115,7 @@ The value for the `sources` key is list of source descriptions, each of which is
 
 The UFO in which the source data is stored is _implied by the global portion of the source location_, via the `.designspace` document.
 
-For example, if a source location is `Weight=800, Width=30, LocalAxis=23`, where "Weight" and "Width" are global axes, and "LocalAxis" a local axis, the source UFO will be the one associated with `Weight=800, Width=30`. This means that the _must_ be a source defined in the `.designspace` document for the global portion of the location.
+For example, if a source location is at `Weight=800, Width=30, LocalAxis=23`, where "Weight" and "Width" are global axes, and "LocalAxis" a local axis, the source UFO will be the one associated with `Weight=800, Width=30`. This means that the _must_ be a source defined in the `.designspace` document for the global portion of the location.
 
 If a variable glyph defines a local axis with the _same name_ as a global axis, it has precedence over the global axis, and an axis value for this axis in a source location belongs to the _local_ portion of the location, and therefore does _not_ participate in deciding which UFO the source data is stored in.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These items correspond to the same-named `.designspace` `<axis>` attributes. All
 
 ### Variation sources
 
-Each variation source defines a location in the augmented design space. The location implicitily determines in which UFO the glyph source data is stored. The UFO _layer_ is defined explicitly.
+Each variation source defines a location in the augmented design space. The location _implicitly_ determines in which UFO the glyph source data is stored. The UFO _layer_ is defined explicitly.
 
 The value for the `sources` key is list of source descriptions, each of which is a dictionary with the following fields:
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If a source location does not contain a value for a locally defined axis, the ax
 
 _The behavior for this situation is still a bit of an open question._
 
-Fontra does have a defined behavior in the case, which I will try to describe below. But I am not convinced this is generally useful behavior, and it complicates things and is hard to explain.
+Fontra does have a defined behavior in this case, which I will try to describe below. But I am not convinced this is generally useful behavior, and it complicates things and is hard to explain.
 
 When rendering a glyph with a local axis that has the same name as a global axis, the global axis value is remapped from `.designspace` "design space coordinates" to the local axis range. A glyph can therefore effectively override the global axis range value with its own. Note that this breaks down if in one coordinate space the default axis value is the same as a minimum or maximum value, but the other coordinate space it is not, or vice versa.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The value for the `sources` key is list of source descriptions, each of which is
 | key | value | optional? |
 |-|-|-|
 | `name` | The UI name for the source | mandatory -- it has no significance for the data, but it is helpful for designers to identify the source |
-| `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. The keys can be global axis names and local axis names defined for this glyph. If an axis is omitted, the default value for that axis is used. | mandatory |
+| `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. Each axis name must either be a global axis name, or a local axis name, defined for this glyph. If an axis is omitted, the default value for that axis is used. | mandatory |
 | `layername` | The UFO layer containing the source glyph data | optional: if not given, the default layer is used |
 
 ### Which UFO?

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Axis values are passed down the component hierarchy, and can per component be ov
 
 For example, we have a glyph `/A`, which has a component referencing a glyph `/B`, which in turn references a glyph `/C`. `/C` responds to the global "Weight" axis (meaning it has source locations that include "Weight" variations), but `/B` does not. When we render glyph `/A` at `Weight=234`, that location is passed to `/B`, but `/B` doesn't specify "Weight" in its location for `/C`. `Weight=234` is passed to `/C` in addition to the axis values that `/B` _does_ specify for `/C`.
 
-### Missing Axis values
+### Missing axis values in source locations
 
 If a source location does not contain a value for a locally defined axis, the axis' default value is implied.
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ The order of operations is significant.
 
 Example Python code implementing this is included here: [compose_transform.py](compose_transform.py). The example code also includes a method for decomposing an Affine transform into decomposed parameters.
 
+### Axis values versus nested components
+
+Each glyph's rendered location is determined by its parent composite. If there is no parent, the global design space location is used.
+
+Axis values are passed down the component hierarchy, and can per component be overwritten by an axis value in the component's location. Another way of describing this is this: component locations may be sparse, which allows parent locations to be passed down the component hierarchy.
+
+For example, we have a glyph `/A`, which has a component referencing a glyph `/B`, which in turn references a glyph `/C`. `/C` responds to the global "Weight" axis (meaning it has source locations that include "Weight" variations), but `/B` does not. When we render glyph `/A` at `Weight=234`, that location is passed to `/B`, but `/B` doesn't specify "Weight" in its location for `/C`. `Weight=234` is passed to `/C` in addition to the axis values that `/B` _does_ specify for `/C`.
+
 ### Missing Axis values
 
 If a source location does not contain a value for a locally defined axis, the axis' default value is implied.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The UFO in which the source data is stored is _implied by the global portion of 
 
 For example, if a source location is at `Weight=800, Width=30, LocalAxis=23`, where "Weight" and "Width" are global axes, and "LocalAxis" is a local axis, the source UFO will be the one associated with `Weight=800, Width=30`. There _must_ be a source defined in the `.designspace` document for the global portion of the location.
 
-If a variable glyph defines a local axis with the _same name_ as a global axis, it has precedence over the global axis, and an axis value for this axis in a source location belongs to the _local_ portion of the location, and therefore does _not_ participate in deciding which UFO the source data is stored in.
+If a variable glyph defines a local axis with the _same name_ as a global axis, the local axis has precedence over the global axis. An axis value for such an axis in a source location belongs to the _local portion_ of the location, and therefore does _not_ participate in deciding which UFO the source data is stored in.
 
 ## Processing
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If a source location does not contain a value for a locally defined axis, the ax
 
 ### Local Axes that use the same name as Global Axes
 
-The behavior for this is a bit of an open question.
+_The behavior for this situation is still a bit of an open question._
 
 Fontra does have a defined behavior in the case, which I will try to describe below. But I am not convinced this is generally useful behavior, and it complicates things and is hard to explain.
 

--- a/README.md
+++ b/README.md
@@ -148,9 +148,13 @@ For example, we have a glyph `/A`, which has a component referencing a glyph `/B
 
 If a source location does not contain a value for a locally defined axis, the axis' default value is implied.
 
-### Local Axes that redefine Global Axes
+### Local Axes that use the same name as Global Axes
 
-_To be defined_
+The behavior for this is a bit of an open question.
+
+Fontra does have a defined behavior in the case, which I will try to describe below. But I am not convinced this is generally useful behavior, and it complicates things and is hard to explain.
+
+When rendering a glyph with a local axis that has the same name as a global axis, the global axis value is remapped from `.designspace` "design space coordinates" to the local axis range. A glyph can therefore effectively override the global axis range value with its own. Note that this breaks down if in one coordinate space the default axis value is the same as a minimum or maximum value, but the other coordinate space it is not, or vice versa.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The value for the `sources` key is list of source descriptions, each of which is
 | key | value | optional? |
 |-|-|-|
 | `name` | The UI name for the source | mandatory -- it has no significance for the data, but it is helpful for designers to identify the source |
-| `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. If an axis is omitted, the default value for that axis is used. | mandatory |
+| `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. The keys can be global axis names and local axis names defined for this glyph. If an axis is omitted, the default value for that axis is used. | mandatory |
 | `layername` | The UFO layer containing the source glyph data | optional: if not given, the default layer is used |
 
 ### Which UFO?

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These items correspond to the same-named `.designspace` `<axis>` attributes. All
 
 ### Variation sources
 
-Each variation source defines a location in the augmented design space, and implicitily defines in which UFO the glyph source data is stored, and explicitly in which UFO layer of that UFO.
+Each variation source defines a location in the augmented design space. The location implicitily determines in which UFO the glyph source data is stored. The UFO _layer_ is defined explicitly.
 
 The value for the `sources` key is list of source descriptions, each of which is a dictionary with the following fields:
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The value for the `sources` key is list of source descriptions, each of which is
 | key | value | optional? |
 |-|-|-|
 | `name` | The UI name for the source | mandatory -- it has no significance for the data, but it is helpful for designers to identify the source |
-| `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. Each axis name must either be a global axis name, or a local axis name, defined for this glyph. If an axis is omitted, the default value for that axis is implied. | mandatory |
+| `location` | The design space `location` of the source, as a dictionary of axis name / axis value pairs. Each axis name must either be a global axis name, or a local axis name defined for this glyph. If an axis is omitted, the default value for that axis is implied. | mandatory |
 | `layername` | The UFO layer containing the source glyph data | optional: if not given, the default layer is used |
 
 ### Which UFO?

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These items correspond to the same-named `.designspace` `<axis>` attributes. All
 
 ### Variation sources
 
-Each variation source defines a location in the augmented design space, and defines in which UFO and which UFO layer the glyph source data is defined.
+Each variation source defines a location in the augmented design space, and implicitily defines in which UFO the glyph source data is stored, and explicitly in which UFO layer of that UFO.
 
 The value for the `sources` key is list of source descriptions, each of which is a dictionary with the following fields:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If there are no variable components, the list should *not* be written to `glyph.
 
 ### Base name
 
-The value for the `base` key is the glyph name of the referenced glyph.
+The value for the `base` key is the glyph name of the referenced glyph. (The name for this key is chosen for symmetry with the `<component>` element in UFO glyphs, which has a `base` attribute with the same function.)
 
 ### Component Transformation
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The value for the `sources` key is list of source descriptions, each of which is
 
 The UFO in which the source data is stored is _implied by the global portion of the source location_, via the `.designspace` document.
 
-For example, if a source location is at `Weight=800, Width=30, LocalAxis=23`, where "Weight" and "Width" are global axes, and "LocalAxis" a local axis, the source UFO will be the one associated with `Weight=800, Width=30`. This means that the _must_ be a source defined in the `.designspace` document for the global portion of the location.
+For example, if a source location is at `Weight=800, Width=30, LocalAxis=23`, where "Weight" and "Width" are global axes, and "LocalAxis" is a local axis, the source UFO will be the one associated with `Weight=800, Width=30`. There _must_ be a source defined in the `.designspace` document for the global portion of the location.
 
 If a variable glyph defines a local axis with the _same name_ as a global axis, it has precedence over the global axis, and an axis value for this axis in a source location belongs to the _local_ portion of the location, and therefore does _not_ participate in deciding which UFO the source data is stored in.
 


### PR DESCRIPTION
While finishing the Fontra implementation of this found some flaws in the current proposal. I will address those in this PR.

Things to address:
- [x] The interaction between the sources in a designspace file and local sources: the global designspace is _augmented_ by the local one, and the default source _always_ comes from the designspace system, and should not be mentioned as a local source
- [x] Which UFO should be used to store a local source layer: it depends on the _global_ portion of the local source location

[Rendered README.md](https://github.com/googlefonts/variable-components-in-ufo/blob/sync-with-fontra-implementation/README.md)